### PR TITLE
Fix: Changed go-appengine-logging to go-logging

### DIFF
--- a/store.go
+++ b/store.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/memcache"
 
-	"github.com/dsoprea/go-appengine-logging"
+	"github.com/dsoprea/go-logging"
 	gcontext "github.com/gorilla/context"
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"


### PR DESCRIPTION
I encountered the following error message while running [Firebase Auth Example](https://qiita.com/koki_cheese/items/f90b1f7359054db57e26).
```
/Users/***/go/src/github.com/k2wanko/go-appengine-sessioncascade/store.go:18:2: imported and not used: "github.com/dsoprea/go-appengine-logging" as aelog
/Users/***/go/src/github.com/k2wanko/go-appengine-sessioncascade/store.go:73:14: undefined: log
/Users/***/go/src/github.com/k2wanko/go-appengine-sessioncascade/store.go:502:3: undefined: log
```
"go-appengine-logging" was replaced by "go-logging" and then I confirmed that Firebase Auth Example works just fine.